### PR TITLE
Created a build script that does an 'npm install' automatically on first build

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "node scripts/build.js",
     "cli": "node dist/index.js",
     "cli-ts": "ts-node src/index.ts",
     "lint": "eslint .",

--- a/cli/scripts/build.js
+++ b/cli/scripts/build.js
@@ -1,0 +1,27 @@
+const { exec } = require('child_process');
+const fs = require('fs/promises');
+
+const execPromise = (command) => {
+    const child = exec(command);
+    const promise = new Promise((resolve, reject) => {
+        child.addListener('error', reject);
+        child.addListener('exit', resolve);
+    });
+    child.promise = promise;
+    return child;
+}
+
+const build = async () => {
+    // Do a first dependency install if needed.
+    try {
+        await fs.access('package-lock.json');
+    }
+    catch {
+        await execPromise('npm install').promise;
+    }
+
+    // Build the application.
+    await execPromise('tsc').promise;
+}
+
+build();


### PR DESCRIPTION
This prevents users from needing to do `npm install` / `npm i` the first time they build the project (or any subsequent time when they need to wipe the node_modules)