### PR TITLE
Refactored how config is loaded

### DIFF
--- a/cli/src/api/handler.ts
+++ b/cli/src/api/handler.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import JSONBigInt from 'json-bigint';
 import { getToken } from '../auth';
-import { getConfig } from '../common/config';
+import config from '../common/config';
 import { RequestBody, QueryBody, ExpandBody, LookupBody, UpdateBody } from './types';
 
 export interface PublishManifest {
@@ -63,7 +63,7 @@ const createSelectString = (select: string[]) => {
     return '$select=' + select.join(',');
 }
 
-const getApiUrl = async () => `${(await getConfig()).dynamics}/api/data/v9.0`;
+const getApiUrl = async () => `${config.settings.dynamics}/api/data/v9.0`;
 
 const getAuthHeader = async () => ((token) => `${token.tokenType} ${token.accessToken}`)(await getToken());
 

--- a/cli/src/auth/getToken.ts
+++ b/cli/src/auth/getToken.ts
@@ -1,5 +1,6 @@
 import { AuthenticationResult } from '@azure/msal-node';
 import { Lock } from 'semaphore-async-await';
+import config from '../common/config';
 import createToken from './createToken';
 import TokenStore from './tokenStore';
 
@@ -8,7 +9,7 @@ const lock = new Lock();
 export default async (): Promise<AuthenticationResult> => {
     await lock.acquire();
 
-    const store = new TokenStore('.xrm/id');
+    const store = new TokenStore(config.paths.cache.token);
     const idToken = await store.loadToken();
     if (idToken && idToken.expiresOn && new Date(idToken.expiresOn) > new Date()) {
         return idToken;

--- a/cli/src/auth/refreshToken.ts
+++ b/cli/src/auth/refreshToken.ts
@@ -1,9 +1,8 @@
 import msal from '@azure/msal-node';
-import { getConfig } from '../common/config';
+import config from '../common/config';
 
 export default async (refreshToken: string): Promise<msal.AuthenticationResult | undefined> => {
-    const config = await getConfig();
-    const pca = new msal.PublicClientApplication({ auth: config.auth });
+    const pca = new msal.PublicClientApplication({ auth: config.settings.auth });
     const request = {
         refreshToken,
         scopes: [ 'openid' ]

--- a/cli/src/components/attribute/index.ts
+++ b/cli/src/components/attribute/index.ts
@@ -1,14 +1,13 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 
 export const getEntityAttributes = async (entity: string): Promise<string[]> => {
-    const config = await getConfig();
-    const entityDir = getPath(config).attributes(entity);
-    const attributeDirs = await fs.readdir(entityDir);
+    const entityAttributeDir = config.paths.entities(entity).attributes.directory;
+    const attributeDirs = await fs.readdir(entityAttributeDir);
     const attributes = [];
     for (const a in attributeDirs) {
-        const attributeDir = path.join(entityDir, attributeDirs[a]);
+        const attributeDir = path.join(entityAttributeDir, attributeDirs[a]);
         if ((await fs.lstat(attributeDir)).isDirectory()) {
             attributes.push(attributeDirs[a]);
         }

--- a/cli/src/components/attribute/push.ts
+++ b/cli/src/components/attribute/push.ts
@@ -1,6 +1,6 @@
 import api from '../../api';
 import { parseFile, quote } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import AttributeMetadata from '../../types/metadata/AttributeMetadata';
 import { Command } from '../cli';
 import { getProjectEntities } from '../entity';
@@ -8,12 +8,12 @@ import { getEntityAttributes } from '.';
 import Entity from '../../types/entity/Entity';
 
 const loadAttributeDefinition = async (entity: string, attribute: string) => {
-    const file = getPath(await getConfig()).attribute(entity, attribute).definition;
+    const file = config.paths.entities(entity).attributes(attribute).definition;
     return await parseFile<AttributeMetadata>(file);
 }
 
 const loadEntityDefinition = async (entity: string) => {
-    const file = getPath(await getConfig()).entity({ logicalname: entity }).definition;
+    const file = config.paths.entities(entity).definition;
     return await parseFile<Entity>(file);
 }
 

--- a/cli/src/components/attribute/typegen.ts
+++ b/cli/src/components/attribute/typegen.ts
@@ -1,7 +1,7 @@
 import { Project } from 'ts-morph';
 import { getEntityAttributes } from '.';
 import { parseFile } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import AttributeMetadata from '../../types/metadata/AttributeMetadata';
 import { Command } from '../cli';
 import { getProjectEntities } from '../entity';
@@ -9,7 +9,6 @@ import { getProjectEntities } from '../entity';
 const typegen: Command = async (names: string[]) => {
     const project = new Project();
     
-    const config = await getConfig();
     const entities = await getProjectEntities();
     names = names.length === 0 ? entities : names;
     for (const n in names) {
@@ -17,9 +16,9 @@ const typegen: Command = async (names: string[]) => {
         const attributes = await getEntityAttributes(name);
         for (const a in attributes) {
             const attribute = attributes[a];
-            const definitionFile = getPath(config).attribute(name, attribute).definition;
+            const definitionFile = config.paths.entities(name).attributes(attribute).definition;
             const definition = await parseFile<AttributeMetadata>(definitionFile);
-            const typedefFile = getPath(config).attribute(name, attribute).typedef;
+            const typedefFile = config.paths.entities(name).attributes(attribute).typedef;
             
             const typedef = project.createSourceFile(typedefFile, undefined, { overwrite: true });
             typedef.addImportDeclaration({ moduleSpecifier: 'xrm-types', namedImports: [ 'Attribute' ] });

--- a/cli/src/components/entity/index.ts
+++ b/cli/src/components/entity/index.ts
@@ -1,10 +1,9 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 
 export const getProjectEntities = async (): Promise<string[]> => {
-    const config = await getConfig();
-    const entitydir = getPath(config).entities.directory;
+    const entitydir = config.paths.entities.directory;
     return (await Promise.all((await fs.readdir(entitydir)).map(async item => {
         if ((await fs.lstat(path.join(entitydir, item))).isDirectory()) {
             return item;

--- a/cli/src/components/entity/push.ts
+++ b/cli/src/components/entity/push.ts
@@ -1,7 +1,7 @@
 import { detailedDiff } from 'deep-object-diff';
 import api from '../../api';
 import { parseFile, quote } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import EntityMetadata from '../../types/metadata/EntityMetadata';
 import Entity from '../../types/entity/Entity';
 import { Command } from '../cli';
@@ -14,13 +14,12 @@ type Diff = {
 }
 
 const loadDefinition = async (name: string) => {
-    const file = getPath(await getConfig()).entity({ logicalname: name }).definition;
+    const file = config.paths.entities(name).definition;
     return await parseFile<Entity>(file);
 }
 
 const loadMetadata = async (name: string) => {
-    const paths = getPath(await getConfig());
-    const entityFiles = paths.entity({ logicalname: name });
+    const entityFiles = config.paths.entities(name);
     const metadata = await parseFile<EntityMetadata>(entityFiles.metadata);
     return metadata;
 }

--- a/cli/src/components/entity/typegen.ts
+++ b/cli/src/components/entity/typegen.ts
@@ -1,7 +1,7 @@
 import os from 'os';
 import { Project } from 'ts-morph';
 import { parseFile } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import AttributeTypeCode from '../../types/enum/AttributeTypeCode';
 import AttributeMetadata from '../../types/metadata/AttributeMetadata';
 import { getEntityAttributes } from '../attribute';
@@ -29,12 +29,11 @@ const getAttributeType = (attributeType: AttributeTypeCode) => {
 }
 
 const typegen = async (name: string, project: Project) => {
-    const config = await getConfig();
-    const entityPaths = getPath(config).entity({ logicalname: name });
+    const entityPaths = config.paths.entities(name);
     const typeFile = entityPaths.typedef;
     const attributes = await getEntityAttributes(name);
     const attributeMetadata = await Promise.all(attributes.map(async attribute => {
-        const definitionFile = getPath(config).attribute(name, attribute).definition;
+        const definitionFile = entityPaths.attributes(attribute).definition;
         const definition = await parseFile<AttributeMetadata>(definitionFile);
         return definition;
     }));

--- a/cli/src/components/pluginassembly/build.ts
+++ b/cli/src/components/pluginassembly/build.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { v4 as uuid } from 'uuid';
 import { execPromise, exists } from '../../common';
 import { NET_SDK_TOOLS_SN_PATH } from '../../common/constants';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import { replaceVarsInDirectory } from '../../common/vars';
 import { Command } from '../cli';
 import { getPluginAssemblyProjects } from '.';
@@ -12,7 +12,6 @@ import { getPluginAssemblyProjects } from '.';
 const build: Command = async (names: string[]) => {
     names = names.length === 0 ? await getPluginAssemblyProjects() : names;
 
-    const config = await getConfig();
     const projects = names.map(n => ({
         name: n,
         uuid: uuid()
@@ -23,11 +22,11 @@ const build: Command = async (names: string[]) => {
             directory: path.join(root),
             dll: path.join(root, 'bin', 'Debug', 'net462', `${n.name}.dll`),
             key: path.join(root, `${n.name}.snk`),
-            output: getPath(config).pluginassembly(n.name).content
+            output: config.paths.pluginAssemblies(n.name).content
         });
         return {
-            build: f(path.join(config.project.pluginassemblies, n.uuid)),
-            source: f(path.join(config.project.pluginassemblies, n.name))
+            build: f(path.join(config.settings.project.pluginassemblies, n.uuid)),
+            source: f(path.join(config.settings.project.pluginassemblies, n.name))
         };
     });
 

--- a/cli/src/components/pluginassembly/index.ts
+++ b/cli/src/components/pluginassembly/index.ts
@@ -1,11 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { exists } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 
 export const getPluginAssemblyComponents = async (): Promise<string[]> => {
-    const config = await getConfig();
-    const componentRoot = getPath(config).pluginassemblies;
+    const componentRoot = config.paths.pluginAssemblies.directory;
     const components = (await Promise.all(
         (await fs.readdir(componentRoot)).map(async item => {
             const p = path.join(componentRoot, item);
@@ -21,10 +20,9 @@ export const getPluginAssemblyComponents = async (): Promise<string[]> => {
 }
 
 export const getPluginAssemblyProjects = async (): Promise<string[]> => {
-    const config = await getConfig();
     const projects = (await Promise.all(
-        (await fs.readdir(config.project.pluginassemblies)).map(async item => {
-            const p = path.join(config.project.pluginassemblies, item);
+        (await fs.readdir(config.settings.project.pluginassemblies)).map(async item => {
+            const p = path.join(config.settings.project.pluginassemblies, item);
             if ((await fs.lstat(p)).isDirectory() && (await fs.readdir(p)).find(file => file === `${item}.csproj`)) {
                 return item;
             }

--- a/cli/src/components/pluginassembly/pull.ts
+++ b/cli/src/components/pluginassembly/pull.ts
@@ -1,20 +1,19 @@
 import api from '../../api';
 import { isUuid, mkdir, quote, saveFile, saveFileB64 } from '../../common';
-import Config, { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import PluginAssembly from '../../types/entity/PluginAssembly';
 import { ComponentType } from '../../types/entity/SolutionComponent';
 import { Command } from '../cli';
 import { getProjectSolutionComponents } from '../solutioncomponent';
 
-const save = async (config: Config, pluginAssembly: PluginAssembly) => {
-    const paths = getPath(config).pluginassembly(pluginAssembly.name);
+const save = async (pluginAssembly: PluginAssembly) => {
+    const paths = config.paths.pluginAssemblies(pluginAssembly.name);
     await mkdir(paths.directory);
     await saveFile(paths.definition, { ...pluginAssembly, content: undefined });
-    await saveFileB64(paths.content as string, pluginAssembly.content);
+    await saveFileB64(paths.content, pluginAssembly.content);
 }
 
 const pull: Command = async (names: string[]) => {
-    const config = await getConfig();
     const [ _, components ] = await getProjectSolutionComponents(ComponentType.PluginAssembly);
     names = (names.length === 0 ? Array.from(components.map(c => c.objectid)) : names);
 
@@ -37,7 +36,7 @@ const pull: Command = async (names: string[]) => {
                 }
                 else if (!pluginAssemblies.has(results[0].pluginassemblyid)) {
                     pluginAssemblies.add(results[0].pluginassemblyid);
-                    await save(config, results[0]);
+                    await save(results[0]);
                 }
                 break;
             default:

--- a/cli/src/components/pluginassembly/push.ts
+++ b/cli/src/components/pluginassembly/push.ts
@@ -1,7 +1,7 @@
 import { detailedDiff } from 'deep-object-diff';
 import api from '../../api';
 import { parseFile, parseFileB64, quote } from '../../common';
-import Config, { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import PluginAssembly from '../../types/entity/PluginAssembly';
 import { Command } from '../cli';
 import { getPluginAssemblyComponents } from '.';
@@ -12,9 +12,9 @@ interface Diff {
     updated: Record<string, unknown>;
 }
 
-const load = async (config: Config, name: string) => {
-    const definitionFile = getPath(config).pluginassembly(name).definition;
-    const contentFile = getPath(config).pluginassembly(name).content;
+const load = async (name: string) => {
+    const definitionFile = config.paths.pluginAssemblies(name).definition;
+    const contentFile = config.paths.pluginAssemblies(name).content;
     const definition = await parseFile<PluginAssembly>(definitionFile);
     if (contentFile) {
         definition.content = await parseFileB64(contentFile);
@@ -25,9 +25,8 @@ const load = async (config: Config, name: string) => {
 const push: Command = async (names: string[]) => {
     names = names.length === 0 ? await getPluginAssemblyComponents() : names;
 
-    const config = await getConfig();
     for (let i = 0; i < names.length; i++) {
-        const pluginAssembly = await load(config, names[i]);
+        const pluginAssembly = await load(names[i]);
         const results = await api.pluginAssembly.query({
             filter: { name: quote(names[i]) }
         }).execute();

--- a/cli/src/components/solution/add.ts
+++ b/cli/src/components/solution/add.ts
@@ -1,12 +1,11 @@
 import api from '../../api';
 import { isUuid, quote } from '../../common';
-import { getConfig, saveConfig } from '../../common/config';
+import config from '../../common/config';
 import { Command } from '../cli';
 
 const add: Command = async (names?: string[]) => {
-    const config = await getConfig();
     names = names ?? [];
-    const solutions = config.project.solutions ?? [];
+    const solutions = config.settings.project.solutions ?? [];
     const set = new Set<string>(solutions);
 
     for (let i = 0; i < names.length; i++) {
@@ -34,7 +33,7 @@ const add: Command = async (names?: string[]) => {
         }
     }
 
-    config.project.solutions = solutions;
-    await saveConfig(config);
+    config.settings.project.solutions = solutions;
+    console.error('Adding solutions is not currently supported');
 }
 export default add;

--- a/cli/src/components/solution/clean.ts
+++ b/cli/src/components/solution/clean.ts
@@ -1,12 +1,10 @@
 import api from '../../api';
 import { isUuid, quote } from '../../common';
-import { getConfig, saveConfig } from '../../common/config';
+import config from '../../common/config';
 import { Command } from '../cli';
 
 const clean: Command = async () => {
-    const config = await getConfig();
-
-    const solutions = config.project?.solutions ?? [];
+    const solutions = config.settings.project.solutions;
     const set: Set<string> = new Set();
     for (let i = 0; i < solutions.length; i++) {
         const name = solutions[i];
@@ -19,7 +17,7 @@ const clean: Command = async () => {
         }
     }
 
-    config.project.solutions = Array.from(set);
-    await saveConfig(config);
+    config.settings.project.solutions = Array.from(set);
+    console.error('Cleaning solutions is not currently supported');
 }
 export default clean;

--- a/cli/src/components/solution/index.ts
+++ b/cli/src/components/solution/index.ts
@@ -1,12 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { parseFile } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import Solution from '../../types/entity/Solution';
 
 export const getProjectSolutionFiles = async (names?: string[]): Promise<string[]> => {
-    const config = await getConfig();
-    const folder = getPath(config).solutions;
+    const folder = config.paths.solutions.directory;
     const dir = await fs.readdir(folder);
     const files = dir.map(f => path.join(folder, f));
     if (names && names.length > 0) {

--- a/cli/src/components/solution/list.ts
+++ b/cli/src/components/solution/list.ts
@@ -1,6 +1,6 @@
 import api from '../../api';
 import { isUuid } from '../../common';
-import { getConfig } from '../../common/config';
+import config from '../../common/config';
 import { getProjectSolutions } from '.';
 
 type ListRow = {
@@ -13,7 +13,7 @@ type ListRow = {
 
 const list = async (): Promise<void> => {
     const solutions = new Map<string, ListRow>();
-    ((await getConfig()).project.solutions ?? []).forEach(s => {
+    (config.settings.project.solutions ?? []).forEach(s => {
         if (!isUuid(s)) {
             return;
         }

--- a/cli/src/components/solution/pull.ts
+++ b/cli/src/components/solution/pull.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import api from '../../api';
 import { isUuid, mkdir, quote, saveFile } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import Solution from '../../types/entity/Solution';
 import { Command } from '../cli';
 
@@ -12,10 +12,8 @@ const save = async (outdir: string, solution: Solution) => {
 }
 
 const pull: Command = async (names: string[]) => {
-    const config = await getConfig();
-
-    names = (names.length === 0 ? config.project.solutions : names);
-    const outdir = getPath(config).solutions;
+    names = (names.length === 0 ? config.settings.project.solutions : names);
+    const outdir = config.paths.solutions.directory;
     
     const solutions = new Set<string>();
     for (let i = 0; i < names?.length; i++) {

--- a/cli/src/components/solution/remove.ts
+++ b/cli/src/components/solution/remove.ts
@@ -1,13 +1,12 @@
-import { getConfig, saveConfig } from '../../common/config';
+import config from '../../common/config';
 import { Command } from '../cli';
 
 const remove: Command = async (names: string[]) => {
-    const config = await getConfig();
-    const solutions = config.project.solutions ?? [];
+    const solutions = config.settings.project.solutions ?? [];
     const set = new Set<string>(solutions);
 
     if (names.length === 0) {
-        config.project.solutions = [];
+        config.settings.project.solutions = [];
     }
     else {
         for (let i = 0; i < names.length; i++) {
@@ -19,10 +18,8 @@ const remove: Command = async (names: string[]) => {
                 console.warn(`Project doesn't contain a solution for ${name}`);
             }
         }
-        config.project.solutions = Array.from(set);
+        config.settings.project.solutions = Array.from(set);
     }
-
-
-    await saveConfig(config);
+    console.error('Removing solutions is not currently supported');
 }
 export default remove;

--- a/cli/src/components/systemform/index.ts
+++ b/cli/src/components/systemform/index.ts
@@ -1,11 +1,10 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import { ProjectForm } from './types';
 
 export const getEntityForms = async (entity: string): Promise<ProjectForm[]> => {
-    const config = await getConfig();
-    const entityDir = getPath(config).systemforms(entity);
+    const entityDir = config.paths.entities(entity).systemForms.directory;
     const formDirs = await fs.readdir(entityDir);
     const forms: ProjectForm[] = [];
     for (let i = 0; i < formDirs.length; i++) {

--- a/cli/src/components/systemform/typegen.ts
+++ b/cli/src/components/systemform/typegen.ts
@@ -1,7 +1,7 @@
 import { Project, SourceFile } from 'ts-morph';
 import { getEntityForms } from '.';
 import { parseFileXML } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import { generateMethod } from '../../common/typegen';
 import { Command } from '../cli';
 import { getProjectEntities } from '../entity';
@@ -274,10 +274,9 @@ const saveTypeDef = (form: Form, sourceFile: SourceFile) => {
 }
 
 const typegenForm = async (entity: string, projectForm: ProjectForm, project: Project) => {
-    const config = await getConfig();
     for (const t in projectForm.types) {
         const type = projectForm.types[t];
-        const paths = getPath(config).systemform(entity, projectForm.name, type.name);
+        const paths = config.paths.entities(entity).systemForms(projectForm.name, type.name);
         const file = paths.typedef;
         const fileXml = paths.form;
         const formXml = await loadFormXml(fileXml);

--- a/cli/src/components/webresource/build.ts
+++ b/cli/src/components/webresource/build.ts
@@ -1,22 +1,21 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { execPromise } from '../../common';
-import { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import { WebResourceType } from '../../types/entity/WebResource';
 import { Command } from '../cli';
 import { getWebResourceProjects } from '.'
 
 const build: Command = async () => {
     const names = await getWebResourceProjects();
-    const config = await getConfig();
     const projects = names.map(n => ({
-        dist: path.join(config.project.webresources, 'dist', n.replace(/\.ts/g, '.js')),
-        src: path.join(config.project.webresources, 'src', n),
-        output: getPath(config).webresource({ name: n.replace(/\.(ts|js)/g, ''), webresourcetype: WebResourceType.JScript }).content as string
+        dist: path.join(config.settings.project.webresources, 'dist', n.replace(/\.ts/g, '.js')),
+        src: path.join(config.settings.project.webresources, 'src', n),
+        output: config.paths.webResources(n.replace(/\.(ts|js)/g, ''), WebResourceType.JScript).content
     }));
 
     // Build the web resource project.
-    await execPromise(`npm run build --prefix "${config.project.webresources}"`).promise;
+    await execPromise(`npm run build --prefix "${config.settings.project.webresources}"`).promise;
 
     await Promise.all(
         projects.map(async p => {

--- a/cli/src/components/webresource/index.ts
+++ b/cli/src/components/webresource/index.ts
@@ -1,13 +1,12 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { getConfig } from '../../common/config';
+import config from '../../common/config';
 import { WebResourceType } from '../../types/entity/WebResource';
 
 export const getExtension = (webResource: { webresourcetype: WebResourceType }): string => WebResourceType[webResource.webresourcetype].toLowerCase().replace(/jscript/g, 'js');
 
 export const getWebResourceProjects = async (): Promise<string[]> => {
-    const config = await getConfig();
-    const root = path.join(config.project.webresources, 'src');
+    const root = path.join(config.settings.project.webresources, 'src');
     const webResources = (await Promise.all(
         (await fs.readdir(root)).map(async item => {
             const p = path.join(root, item);

--- a/cli/src/components/webresource/pull.ts
+++ b/cli/src/components/webresource/pull.ts
@@ -1,20 +1,19 @@
 import api from '../../api';
 import { isUuid, mkdir, quote, saveFile, saveFileB64 } from '../../common';
-import Config, { getConfig, getPath } from '../../common/config';
+import config from '../../common/config';
 import { ComponentType } from '../../types/entity/SolutionComponent';
 import WebResource from '../../types/entity/WebResource';
 import { Command } from '../cli';
 import { getProjectSolutionComponents } from '../solutioncomponent';
 
-const save = async (config: Config, webResource: WebResource) => {
-    const paths = getPath(config).webresource(webResource);
+const save = async (webResource: WebResource) => {
+    const paths = config.paths.webResources(webResource.name, webResource.webresourcetype);
     await mkdir(paths.directory);
     await saveFile(paths.definition, { ...webResource, content: undefined });
-    await saveFileB64(paths.content as string, webResource.content);
+    await saveFileB64(paths.content, webResource.content);
 }
 
 const pull: Command = async (names: string[]) => {
-    const config = await getConfig();
     const [ _, components ] = await getProjectSolutionComponents(ComponentType.WebResource);
     names = (names.length === 0 ? Array.from(components.map(c => c.objectid)) : names);
 
@@ -37,7 +36,7 @@ const pull: Command = async (names: string[]) => {
                 }
                 else if (!webResources.has(results[0].webresourceid)) {
                     webResources.add(results[0].webresourceid);
-                    await save(config, results[0]);
+                    await save(results[0]);
                 }
                 break;
             default:


### PR DESCRIPTION
Few differences:

- Config is loaded from the first ancestral folder that contains a `xrm.json` config file; this folder also acts as "cwd" for the cli
- Completely changed how config is accessed, only loads file once into memory, big speed boost
- Config is now a singleton class with the following properties
    - `settings`: The settings loaded from `xrm.json`
    - `paths`: similar to `getPaths`, but totally redone to be more consistent across components and with the xrm folder structure
- Introduced the idea of "default" settings that are loaded first, then replaced with user settings
- Introduced the idea of "required keys" for settings that can't have a reasonable default